### PR TITLE
Configure GitHub Actions to Build Wheels on Windows, Linux, and MacOS

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [windows-2016, ubuntu-16.04, macos-latest]
+          os: [windows-2016, ubuntu-latest, macos-latest]
           py: [3.6, 3.7, 3.8]
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,42 @@
+name: Build Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+          os: [windows-2016, ubuntu-latest, macos-latest]
+          py: [3.6, 3.7, 3.8]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.py }}
+
+      - name: Install build requirements
+        if: ${{ contains(matrix.os, 'windows') }}
+        run: choco install swig
+
+      - if: ${{ contains(matrix.os, 'ubuntu') }}
+        run: sudo apt-get install swig
+
+      - if: ${{ contains(matrix.os, 'macos') }}
+        run: brew install libomp swig
+
+      - name: Build wheel
+        run: pip wheel --wheel-dir=./dist ./swmm-toolkit
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/swmm_toolkit*.whl

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [windows-2016, ubuntu-latest, macos-latest]
+          os: [windows-2016, ubuntu-16.04, macos-latest]
           py: [3.6, 3.7, 3.8]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,8 @@
 #  .gitignore for swmm-python repo
 #
 
+!.git*
 
-.*
-!.gitignore
-!.gitmodules
 .DS_Store
 
 *.pyc

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 
 ## Contents
-* nrtest-swmm  - Plugin for performing numerical regression testing on swmm-solver.
-* swmm-toolkit - SWIG based wrappers for the swmm-solver and swmm-output libraries.
-* ...
+nrtest-swmm  - Plugin for performing numerical regression testing on swmm-solver.
+
+
+swmm-toolkit - SWIG based wrappers for the swmm-solver and swmm-output libraries.
+
+![Build Wheels](https://github.com/SWMM-Project/swmm-python/workflows/Build%20Wheels/badge.svg)

--- a/swmm-toolkit/CMakeLists.txt
+++ b/swmm-toolkit/CMakeLists.txt
@@ -14,9 +14,10 @@ cmake_minimum_required (VERSION 3.17)
 project(swmm-toolkit)
 
 
-set(Python_FIND_VIRTUALENV FIRST)
-set(Python_ROOT_DIR "/usr/local/anaconda3")
-find_package(Python 3.7 COMPONENTS Development Interpreter REQUIRED)
+set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
+set(Python_INCLUDE_DIRS ${PYTHON_INCLUDE_DIR})
+set(Python_LIBRARY ${PYTHON_LIBRARY})
+find_package (Python ${PYTHON_VERSION_STRING} COMPONENTS Interpreter Development)
 
 
 find_package(SWIG REQUIRED)

--- a/swmm-toolkit/pyproject.toml
+++ b/swmm-toolkit/pyproject.toml
@@ -1,0 +1,6 @@
+
+
+
+[build-system]
+requires = ["setuptools", "wheel", "scikit-build", "cmake"]
+build-backend = "setuptools.build_meta"

--- a/swmm-toolkit/src/swmm/toolkit/CMakeLists.txt
+++ b/swmm-toolkit/src/swmm/toolkit/CMakeLists.txt
@@ -13,21 +13,27 @@ set(CMAKE_SWIG_FLAGS -py3)
 
 # Determine filename suffix for python extension
 if(WIN32)
-    set(Python_EXTENSION ".${Python_SOABI}.pyd")
+    set(LIB_EXT "pyd")
 else()
-    set(Python_EXTENSION ".${Python_SOABI}.so")
+    set(LIB_EXT "so")
 endif()
+
+set(Python_EXTENSION ".${Python_SOABI}.${LIB_EXT}")
 
 
 # Location of package at runtime on MacOS/Linux
 if(APPLE)
-    set(PACKAGE_RPATH "@loader_path/../../../..;@loader_path/../../../../extern")
+    set(LIB_ROOT "@loader_path")
 else()
-    set(PACKAGE_RPATH "$ORIGIN/../../../..;$ORIGIN/../../../../extern")
+    set(LIB_ROOT "$ORIGIN")
 endif()
 
+set(PACKAGE_RPATH "${LIB_ROOT}/../../../..;${LIB_ROOT}/../../../../extern")
 
-#######   OUTPUT TARGET   #######
+
+#############################################################
+####################    OUTPUT TARGET    ####################
+#############################################################
 
 set_property(SOURCE output.i
     PROPERTY
@@ -48,9 +54,14 @@ target_link_options(output
         $<$<BOOL:${APPLE}>:-undefineddynamic_lookup>
 )
 
+target_include_directories(output
+    PUBLIC
+        ${Python_INCLUDE_DIRS}
+)
+
 target_link_libraries(output
     PUBLIC
-        Python::Module
+        $<$<BOOL:$<C_COMPILER_ID:MSVC>>:Python::Module>
         swmm-output
 )
 
@@ -82,8 +93,9 @@ install(
         "src/swmm/toolkit"
 )
 
-
-#######   SOLVER TARGET   #######
+#############################################################
+####################    SOLVER TARGET    ####################
+#############################################################
 
 set_property(SOURCE solver.i
     PROPERTY
@@ -104,9 +116,14 @@ target_link_options(solver
         $<$<BOOL:${APPLE}>:-undefineddynamic_lookup>
 )
 
+target_include_directories(solver
+    PUBLIC
+        ${Python_INCLUDE_DIRS}
+)
+
 target_link_libraries(solver
     PUBLIC
-        Python::Module
+        $<$<BOOL:$<C_COMPILER_ID:MSVC>>:Python::Module>
         swmm5
 )
 


### PR DESCRIPTION
I would like to start by thanking @lrntct for his work on PR #39. This PR builds directly on that effort.  

This PR does the following: 
 - configures GitHub Actions to build wheels
 - builds wheel directly on the build runner
 - eliminates use of ci-build_wheel
 - eliminates use of manylinux images

This results in a build workflow that is easier to configure and maintain. The resulting Linux wheels are compliant with "manylinux2014_x86_64" platform tag. 
