### PR TITLE
SWIG development cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 !.git*
 
+.vscode
+
 .DS_Store
 
 *.pyc

--- a/swmm-toolkit/LICENSE.md
+++ b/swmm-toolkit/LICENSE.md
@@ -156,4 +156,4 @@ For more information, please see
 # Third-Party Libraries
 
 
-## SWMM
+## OWA SWMM

--- a/swmm-toolkit/src/swmm/toolkit/output.i
+++ b/swmm-toolkit/src/swmm/toolkit/output.i
@@ -29,28 +29,16 @@
 %delobject SMO_close;
 
 
-/* TYPEMAPS FOR VOID POINTER */
+/* TYPEMAPS FOR HANDLE POINTER */
 /* Used for functions that output a new opaque pointer */
-%typemap(in, numinputs=0) SMO_Handle *p_handle (void *retval)
-{
- /* OUTPUT in */
-    retval = NULL;
-    $1 = &retval;
+%typemap(in,numinputs=0) SMO_Handle *p_handle (SMO_Handle temp) {
+    $1 = &temp;
 }
 /* used for functions that take in an opaque pointer (or NULL)
 and return a (possibly) different pointer */
-%typemap(argout) SMO_Handle *p_handle
-{
- /* OUTPUT argout */
-    %append_output(SWIG_NewPointerObj(SWIG_as_voidptr(retval$argnum), $1_descriptor, 0));
+%typemap(argout) SMO_Handle *p_handle {
+    %append_output(SWIG_NewPointerObj(*$1, SWIGTYPE_p_Handle, SWIG_POINTER_NEW));
 }
-%typemap(in) SMO_Handle *p_handle_inout (SMO_Handle retval)
-{
-   /* INOUT in */
-   SWIG_ConvertPtr($input, SWIG_as_voidptrptr(&retval), 0, 0);
-   $1 = &retval;
-}
-/* No need for special IN typemap for opaque pointers, it works anyway */
 
 
 /* TYPEMAP FOR IGNORING INT ERROR CODE RETURN VALUE */

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -67,16 +67,14 @@
 };
 
 /* TYPEMAPS FOR MEMORY MANAGEMNET OF DOUBLE ARRAYS */
-%typemap(in, numinputs=0)double** in_out_array (double* temp){
+%typemap(in, numinputs=0)float **double_out (double *temp), int *int_dim (int temp){
    $1 = &temp;
 }
-%typemap(argout) (double** in_out_array) {
-    if (*$1)
-    {
-      int length = sizeof(*$1)/sizeof(double) + 1;
-      PyObject *o = PyList_New(length);
+%typemap(argout) (float **double_out, int *int_dim) {
+    if (*$1) {
+      PyObject *o = PyList_New(*$2);
       double* temp = *$1;
-      for(int i=0; i<length; i++) {
+      for(int i=0; i<*$2; i++) {
         PyList_SetItem(o, i, PyFloat_FromDouble(temp[i]));
       }
       $result = SWIG_Python_AppendOutput($result, o);
@@ -350,7 +348,7 @@ int  swmm_getNodeType(int index, int *OUTPUT);
 int  swmm_getNodeParam(int index, SM_NodeProperty parameter, double *OUTPUT);
 int  swmm_setNodeParam(int index, SM_NodeProperty parameter, double value);
 int  swmm_getNodeResult(int index, SM_NodeResult type, double *OUTPUT);
-int  swmm_getNodePollut(int index, SM_NodePollut type, double** in_out_array);
+int  swmm_getNodePollut(int index, SM_NodePollut type, double **double_out, int *int_dim);
 int  swmm_getNodeTotalInflow(int index, double *OUTPUT);
 int  swmm_setNodeInflow(int index, double flowrate);
 int  swmm_setOutfallStage(int index, double stage);
@@ -364,7 +362,7 @@ int  swmm_getLinkDirection(int index, signed char *value);
 int  swmm_getLinkParam(int index, SM_LinkProperty parameter, double *OUTPUT);
 int  swmm_setLinkParam(int index, SM_LinkProperty parameter, double value);
 int  swmm_getLinkResult(int index, SM_LinkResult type, double *OUTPUT);
-int  swmm_getLinkPollut(int index, SM_LinkPollut type, double **in_out_array);
+int  swmm_getLinkPollut(int index, SM_LinkPollut type, double **double_out, int *int_dim);
 int  swmm_setLinkSetting(int index, double setting);
 int  swmm_getLinkStats(int index, SM_LinkStats **in_out_dict);
 int  swmm_getPumpStats(int index, SM_PumpStats **in_out_dict);
@@ -373,7 +371,7 @@ int  swmm_getSubcatchOutConnection(int index, int *OUTPUT, int *OUTPUT);
 int  swmm_getSubcatchParam(int index, SM_SubcProperty parameter, double *OUTPUT);
 int  swmm_setSubcatchParam(int index, SM_SubcProperty parameter, double value);
 int  swmm_getSubcatchResult(int index, SM_SubcResult type, double *OUTPUT);
-int  swmm_getSubcatchPollut(int index, SM_SubcPollut type, double **in_out_array);
+int  swmm_getSubcatchPollut(int index, SM_SubcPollut type, double **double_out, int *int_dim);
 int  swmm_getSubcatchStats(int index, SM_SubcatchStats **in_out_dict);
 
 int  swmm_getLidUCount(int index, int *OUTPUT);

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -40,6 +40,13 @@
 
 
 %apply int *OUTPUT {
+    int *index,
+    int *value,
+    int *count, 
+    int *node1, 
+    int *node2,
+    int *out_index,
+    int *condition,
     int *year,
     int *month,
     int *day,
@@ -51,7 +58,8 @@
 
 %apply double *OUTPUT {
     double *elapsedTime,
-    double *value
+    double *value,
+    double *result
 };
 
 
@@ -75,7 +83,6 @@
 %cstring_output_allocate(char **OUTCHAR, swmm_freeMemory(*$1));
 
 %apply char **OUTCHAR {
-//    char **errorMsg,
     char **id,
     char **major, 
     char **minor, 
@@ -84,20 +91,32 @@
 
 
 /* TYPEMAPS FOR MEMORY MANAGEMNET OF DOUBLE ARRAYS */
-%typemap(in, numinputs=0)float **double_out (double *temp), int *int_dim (int temp){
-   $1 = &temp;
+%typemap(in, numinputs=0) double **double_out (double *temp) {
+    $1=&temp;
 }
-%typemap(argout) (float **double_out, int *int_dim) {
+%typemap(in, numinputs=0) int *int_dim (int temp) {
+    $1=&temp;
+}
+%typemap(argout) (double **double_out, int *int_dim) {
     if (*$1) {
       PyObject *o = PyList_New(*$2);
-      double* temp = *$1;
+      //double *temp = *$1;
       for(int i=0; i<*$2; i++) {
-        PyList_SetItem(o, i, PyFloat_FromDouble(temp[i]));
+        PyList_SetItem(o, i, PyFloat_FromDouble(temp$argnum[i]));
       }
       $result = SWIG_Python_AppendOutput($result, o);
       swmm_freeMemory(*$1);
     }
 }
+%apply double **double_out {
+    double **pollutArray
+};
+%apply int *int_dim {
+    int *length
+}
+%apply (double **double_out, int *int_dim) {
+    (double **pollutArray, int *length)
+};
 
 
 /* TYPEMAP FOR ENUMERATED TYPE INPUT ARGUMENTS */
@@ -170,8 +189,9 @@
 
 
 // TOOLKIT API
-%ignore swmm_freeOutfallStats;
+%ignore swmm_run_cb;
 %ignore swmm_getAPIError;
+%ignore swmm_freeOutfallStats;
 %ignore swmm_freeMemory;
 
 %include "toolkitAPI.h"

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -29,11 +29,15 @@
 %}
 
 
+%include "stats_typemaps.i"
+
+
 /* TYPEMAP FOR IGNORING INT ERROR CODE RETURN VALUE */
 %typemap(out) int {
     $result = Py_None;
     Py_INCREF($result);
 }
+
 
 %apply int *OUTPUT {
     int *year,
@@ -44,10 +48,12 @@
     int *second
 };
 
+
 %apply double *OUTPUT {
     double *elapsedTime,
     double *value
 };
+
 
 %apply float *OUTPUT {
     float *runoffErr,
@@ -55,23 +61,27 @@
     float *qualErr
 };
 
+
 %apply signed char *OUTPUT {
     signed char *value
 };
+
 
 %apply char *OUTPUT {
     char *condition
 };
 
+
 %cstring_output_allocate(char **OUTCHAR, swmm_freeMemory(*$1));
 
 %apply char **OUTCHAR {
-    char **errorMsg,
+//    char **errorMsg,
     char **id,
     char **major, 
     char **minor, 
     char **patch
 };
+
 
 /* TYPEMAPS FOR MEMORY MANAGEMNET OF DOUBLE ARRAYS */
 %typemap(in, numinputs=0)float **double_out (double *temp), int *int_dim (int temp){
@@ -89,174 +99,6 @@
     }
 }
 
-%typemap(in, numinputs=0) SM_NodeStats **in_out_dict (SM_NodeStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_NodeStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "avgDepth", PyFloat_FromDouble((*$1)->avgDepth));
-    PyMapping_SetItemString(o, "maxDepth", PyFloat_FromDouble((*$1)->maxDepth));
-    PyMapping_SetItemString(o, "maxDepthDate", PyFloat_FromDouble((*$1)->maxDepthDate));
-    PyMapping_SetItemString(o, "maxRptDepth", PyFloat_FromDouble((*$1)->maxRptDepth));
-    PyMapping_SetItemString(o, "volFlooded", PyFloat_FromDouble((*$1)->volFlooded));
-    PyMapping_SetItemString(o, "timeFlooded", PyFloat_FromDouble((*$1)->timeFlooded));
-    PyMapping_SetItemString(o, "timeSurcharged", PyFloat_FromDouble((*$1)->timeSurcharged));
-    PyMapping_SetItemString(o, "timeCourantCritical", PyFloat_FromDouble((*$1)->timeCourantCritical));
-    PyMapping_SetItemString(o, "totLatFlow", PyFloat_FromDouble((*$1)->totLatFlow));
-    PyMapping_SetItemString(o, "maxLatFlow", PyFloat_FromDouble((*$1)->maxLatFlow));
-    PyMapping_SetItemString(o, "maxInflow", PyFloat_FromDouble((*$1)->maxInflow));
-    PyMapping_SetItemString(o, "maxOverflow", PyFloat_FromDouble((*$1)->maxOverflow));
-    PyMapping_SetItemString(o, "maxPondedVol", PyFloat_FromDouble((*$1)->maxPondedVol));
-    PyMapping_SetItemString(o, "maxInflowDate", PyFloat_FromDouble((*$1)->maxInflowDate));
-    PyMapping_SetItemString(o, "maxOverflowDate", PyFloat_FromDouble((*$1)->maxOverflowDate));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-
-%typemap(in, numinputs=0) SM_StorageStats **in_out_dict (SM_StorageStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_StorageStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "initVol", PyFloat_FromDouble((*$1)->initVol));
-    PyMapping_SetItemString(o, "avgVol", PyFloat_FromDouble((*$1)->avgVol));
-    PyMapping_SetItemString(o, "maxVol", PyFloat_FromDouble((*$1)->maxVol));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "evapLosses", PyFloat_FromDouble((*$1)->evapLosses));
-    PyMapping_SetItemString(o, "exfilLosses", PyFloat_FromDouble((*$1)->exfilLosses));
-    PyMapping_SetItemString(o, "maxVolDate", PyFloat_FromDouble((*$1)->maxVolDate));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-
-%typemap(in, numinputs=0) SM_OutfallStats **in_out_dict (SM_OutfallStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_OutfallStats **in_out_dict {
-    int length = sizeof((*$1)->totalLoad)/sizeof(double) + 1;
-    PyObject *loads = PyList_New(length);
-    PyObject *o = PyDict_New();
-    for(int i=0; i<length; i++) {
-      PyList_SetItem(loads, i, PyFloat_FromDouble(((*$1)->totalLoad)[i]));
-    }
-    PyMapping_SetItemString(o, "avgFlow", PyFloat_FromDouble((*$1)->avgFlow));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "loads", loads);
-    PyMapping_SetItemString(o, "totalPeriods", PyLong_FromLong((*$1)->totalPeriods));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeOutfallStats(*$1);
-    swmm_freeMemory(*$1);
-}
-
-%typemap(in, numinputs=0) SM_LinkStats **in_out_dict (SM_LinkStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_LinkStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyObject *flowTime = PyDict_New();
-
-    PyMapping_SetItemString(flowTime, "DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[0]));
-    PyMapping_SetItemString(flowTime, "UP_DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[1]));
-    PyMapping_SetItemString(flowTime, "DN_DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[2]));
-    PyMapping_SetItemString(flowTime, "SUBCRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[3]));
-    PyMapping_SetItemString(flowTime, "SUPCRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[4]));
-    PyMapping_SetItemString(flowTime, "UP_CRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[5]));
-    PyMapping_SetItemString(flowTime, "DN_CRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[6]));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "maxFlowDate", PyFloat_FromDouble((*$1)->maxFlowDate));
-    PyMapping_SetItemString(o, "maxVeloc", PyFloat_FromDouble((*$1)->maxVeloc));
-    PyMapping_SetItemString(o, "maxDepth", PyFloat_FromDouble((*$1)->maxDepth));
-    PyMapping_SetItemString(o, "timeNormalFlow", PyFloat_FromDouble((*$1)->timeNormalFlow));
-    PyMapping_SetItemString(o, "timeInletControl", PyFloat_FromDouble((*$1)->timeInletControl));
-    PyMapping_SetItemString(o, "timeSurcharged", PyFloat_FromDouble((*$1)->timeSurcharged));
-    PyMapping_SetItemString(o, "timeFullUpstream", PyFloat_FromDouble((*$1)->timeFullUpstream));
-    PyMapping_SetItemString(o, "timeFullDnstream", PyFloat_FromDouble((*$1)->timeFullDnstream));
-    PyMapping_SetItemString(o, "timeFullFlow", PyFloat_FromDouble((*$1)->timeFullFlow));
-    PyMapping_SetItemString(o, "timeCapacityLimited", PyFloat_FromDouble((*$1)->timeCapacityLimited));
-    PyMapping_SetItemString(o, "timeCourantCritical", PyFloat_FromDouble((*$1)->timeCourantCritical));
-    PyMapping_SetItemString(o, "timeInFlowClass", flowTime);
-    PyMapping_SetItemString(o, "flowTurns", PyLong_FromLong((*$1)->flowTurns));
-    PyMapping_SetItemString(o, "flowTurnSign", PyLong_FromLong((*$1)->flowTurnSign));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-
-%typemap(in, numinputs=0) SM_PumpStats **in_out_dict (SM_PumpStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_PumpStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "utilized", PyFloat_FromDouble((*$1)->utilized));
-    PyMapping_SetItemString(o, "minFlow", PyFloat_FromDouble((*$1)->minFlow));
-    PyMapping_SetItemString(o, "avgFlow", PyFloat_FromDouble((*$1)->avgFlow));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "volume", PyFloat_FromDouble((*$1)->volume));
-    PyMapping_SetItemString(o, "energy", PyFloat_FromDouble((*$1)->energy));
-    PyMapping_SetItemString(o, "offCurveLow", PyFloat_FromDouble((*$1)->offCurveLow));
-    PyMapping_SetItemString(o, "offCurveHigh", PyFloat_FromDouble((*$1)->offCurveHigh));
-    PyMapping_SetItemString(o, "startUps", PyLong_FromLong((*$1)->startUps));
-    PyMapping_SetItemString(o, "totalPeriods", PyLong_FromLong((*$1)->totalPeriods));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-
-%typemap(in, numinputs=0) SM_SubcatchStats **in_out_dict (SM_SubcatchStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_SubcatchStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "precip", PyFloat_FromDouble((*$1)->precip));
-    PyMapping_SetItemString(o, "runon", PyFloat_FromDouble((*$1)->runon));
-    PyMapping_SetItemString(o, "evap", PyFloat_FromDouble((*$1)->evap));
-    PyMapping_SetItemString(o, "infil", PyFloat_FromDouble((*$1)->infil));
-    PyMapping_SetItemString(o, "runoff", PyFloat_FromDouble((*$1)->runoff));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-
-%typemap(in, numinputs=0) SM_RoutingTotals **in_out_dict (SM_RoutingTotals *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_RoutingTotals **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "dwInflow", PyFloat_FromDouble((*$1)->dwInflow));
-    PyMapping_SetItemString(o, "wwInflow", PyFloat_FromDouble((*$1)->wwInflow));
-    PyMapping_SetItemString(o, "gwInflow", PyFloat_FromDouble((*$1)->gwInflow));
-    PyMapping_SetItemString(o, "iiInflow", PyFloat_FromDouble((*$1)->iiInflow));
-    PyMapping_SetItemString(o, "exInflow", PyFloat_FromDouble((*$1)->exInflow));
-    PyMapping_SetItemString(o, "flooding", PyFloat_FromDouble((*$1)->flooding));
-    PyMapping_SetItemString(o, "outflow", PyFloat_FromDouble((*$1)->outflow));
-    PyMapping_SetItemString(o, "evapLoss", PyFloat_FromDouble((*$1)->evapLoss));
-    PyMapping_SetItemString(o, "seepLoss", PyFloat_FromDouble((*$1)->seepLoss));
-    PyMapping_SetItemString(o, "reacted", PyFloat_FromDouble((*$1)->reacted));
-    PyMapping_SetItemString(o, "initStorage", PyFloat_FromDouble((*$1)->initStorage));
-    PyMapping_SetItemString(o, "finalStorage", PyFloat_FromDouble((*$1)->finalStorage));
-    PyMapping_SetItemString(o, "pctError", PyFloat_FromDouble((*$1)->pctError));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-
-%typemap(in, numinputs=0) SM_RunoffTotals **in_out_dict (SM_RunoffTotals *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_RunoffTotals **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "rainfall", PyFloat_FromDouble((*$1)->rainfall));
-    PyMapping_SetItemString(o, "evap", PyFloat_FromDouble((*$1)->evap));
-    PyMapping_SetItemString(o, "infil", PyFloat_FromDouble((*$1)->infil));
-    PyMapping_SetItemString(o, "runoff", PyFloat_FromDouble((*$1)->runoff));
-    PyMapping_SetItemString(o, "drains", PyFloat_FromDouble((*$1)->drains));
-    PyMapping_SetItemString(o, "runon", PyFloat_FromDouble((*$1)->runon));
-    PyMapping_SetItemString(o, "initStorage", PyFloat_FromDouble((*$1)->initStorage));
-    PyMapping_SetItemString(o, "finalStorage", PyFloat_FromDouble((*$1)->finalStorage));
-    PyMapping_SetItemString(o, "initSnowCover", PyFloat_FromDouble((*$1)->initSnowCover));
-    PyMapping_SetItemString(o, "finalSnowCover", PyFloat_FromDouble((*$1)->finalSnowCover));
-    PyMapping_SetItemString(o, "snowRemoved", PyFloat_FromDouble((*$1)->snowRemoved));
-    PyMapping_SetItemString(o, "Continuity Error", PyFloat_FromDouble((*$1)->pctError));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
 
 /* TYPEMAP FOR ENUMERATED TYPE INPUT ARGUMENTS */
 %typemap(in) EnumTypeIn {
@@ -321,72 +163,80 @@
 }
 
 // CANONICAL API
+%ignore swmm_getError;
+%ignore swmm_getWarnings;
+
 %include "swmm5.h"
 
 
-
 // TOOLKIT API
-// int  swmm_getAPIError(int ErrorCodeAPI, char **errorMsg);
-int  swmm_getSimulationUnit(SM_Units type, int *OUTPUT);
-int  swmm_project_findObject(SM_ObjectType type, char *id, int *OUTPUT);
-int  swmm_countObjects(SM_ObjectType type, int *OUTPUT);
-int  swmm_getSimulationDateTime(SM_TimePropety type, int *year, int *month, int *day, int *hour, int *minute, int *second);
-int  swmm_setSimulationDateTime(SM_TimePropety timetype, int year, int month, int day, int hour, int minute, int second);
-int  swmm_getSimulationAnalysisSetting(SM_SimOption type, int *OUTPUT);
-int  swmm_getSimulationParam(SM_SimSetting type, double *OUTPUT);
-int  swmm_getCurrentDateTime(int *year, int *month, int *day, int *hour, int *minute, int *second);
-int  swmm_getSystemRoutingStats(SM_RoutingTotals** in_out_dict);
-int  swmm_getSystemRunoffStats(SM_RunoffTotals** in_out_dict);
+%ignore swmm_freeOutfallStats;
+%ignore swmm_getAPIError;
+%ignore swmm_freeMemory;
 
-int  swmm_getObjectIndex(SM_ObjectType type, char *id, int *OUTPUT);
-int  swmm_getObjectId(SM_ObjectType type, int index, char **id);
+%include "toolkitAPI.h"
 
-int  swmm_getGagePrecip(int index, SM_GagePrecip type, double *OUTPUT);
-int  swmm_setGagePrecip(int index, double total_precip);
+//// int  swmm_getAPIError(int ErrorCodeAPI, char **errorMsg);
+// int  swmm_getSimulationUnit(SM_Units type, int *OUTPUT);
+// int  swmm_project_findObject(SM_ObjectType type, char *id, int *OUTPUT);
+// int  swmm_countObjects(SM_ObjectType type, int *OUTPUT);
+// int  swmm_getSimulationDateTime(SM_TimePropety type, int *year, int *month, int *day, int *hour, int *minute, int *second);
+// int  swmm_setSimulationDateTime(SM_TimePropety timetype, int year, int month, int day, int hour, int minute, int second);
+// int  swmm_getSimulationAnalysisSetting(SM_SimOption type, int *OUTPUT);
+// int  swmm_getSimulationParam(SM_SimSetting type, double *OUTPUT);
+// int  swmm_getCurrentDateTime(int *year, int *month, int *day, int *hour, int *minute, int *second);
+// int  swmm_getSystemRoutingStats(SM_RoutingTotals** in_out_dict);
+// int  swmm_getSystemRunoffStats(SM_RunoffTotals** in_out_dict);
 
-int  swmm_getNodeType(int index, int *OUTPUT);
-int  swmm_getNodeParam(int index, SM_NodeProperty parameter, double *OUTPUT);
-int  swmm_setNodeParam(int index, SM_NodeProperty parameter, double value);
-int  swmm_getNodeResult(int index, SM_NodeResult type, double *OUTPUT);
-int  swmm_getNodePollut(int index, SM_NodePollut type, double **double_out, int *int_dim);
-int  swmm_getNodeTotalInflow(int index, double *OUTPUT);
-int  swmm_setNodeInflow(int index, double flowrate);
-int  swmm_setOutfallStage(int index, double stage);
-int  swmm_getNodeStats(int index, SM_NodeStats **in_out_dict);
-int  swmm_getStorageStats(int index, SM_StorageStats **in_out_dict);
-int  swmm_getOutfallStats(int index, SM_OutfallStats **in_out_dict);
+// int  swmm_getObjectIndex(SM_ObjectType type, char *id, int *OUTPUT);
+// int  swmm_getObjectId(SM_ObjectType type, int index, char **id);
 
-int  swmm_getLinkType(int index, int *OUTPUT);
-int  swmm_getLinkConnections(int index, int *OUTPUT, int *OUTPUT);
-int  swmm_getLinkDirection(int index, signed char *value);
-int  swmm_getLinkParam(int index, SM_LinkProperty parameter, double *OUTPUT);
-int  swmm_setLinkParam(int index, SM_LinkProperty parameter, double value);
-int  swmm_getLinkResult(int index, SM_LinkResult type, double *OUTPUT);
-int  swmm_getLinkPollut(int index, SM_LinkPollut type, double **double_out, int *int_dim);
-int  swmm_setLinkSetting(int index, double setting);
-int  swmm_getLinkStats(int index, SM_LinkStats **in_out_dict);
-int  swmm_getPumpStats(int index, SM_PumpStats **in_out_dict);
+// int  swmm_getGagePrecip(int index, SM_GagePrecip type, double *OUTPUT);
+// int  swmm_setGagePrecip(int index, double total_precip);
 
-int  swmm_getSubcatchOutConnection(int index, int *OUTPUT, int *OUTPUT);
-int  swmm_getSubcatchParam(int index, SM_SubcProperty parameter, double *OUTPUT);
-int  swmm_setSubcatchParam(int index, SM_SubcProperty parameter, double value);
-int  swmm_getSubcatchResult(int index, SM_SubcResult type, double *OUTPUT);
-int  swmm_getSubcatchPollut(int index, SM_SubcPollut type, double **double_out, int *int_dim);
-int  swmm_getSubcatchStats(int index, SM_SubcatchStats **in_out_dict);
+// int  swmm_getNodeType(int index, int *OUTPUT);
+// int  swmm_getNodeParam(int index, SM_NodeProperty parameter, double *OUTPUT);
+// int  swmm_setNodeParam(int index, SM_NodeProperty parameter, double value);
+// int  swmm_getNodeResult(int index, SM_NodeResult type, double *OUTPUT);
+// int  swmm_getNodePollut(int index, SM_NodePollut type, double **double_out, int *int_dim);
+// int  swmm_getNodeTotalInflow(int index, double *OUTPUT);
+// int  swmm_setNodeInflow(int index, double flowrate);
+// int  swmm_setOutfallStage(int index, double stage);
+// int  swmm_getNodeStats(int index, SM_NodeStats **in_out_dict);
+// int  swmm_getStorageStats(int index, SM_StorageStats **in_out_dict);
+// int  swmm_getOutfallStats(int index, SM_OutfallStats **in_out_dict);
 
-int  swmm_getLidUCount(int index, int *OUTPUT);
-int  swmm_getLidUParam(int index, int lidIndex, SM_LidUProperty param, double *OUTPUT);
-int  swmm_setLidUParam(int index, int lidIndex, SM_LidUProperty param, double value);
-int  swmm_getLidUOption(int index, int lidIndex, SM_LidUOptions param, int *OUTPUT);
-int  swmm_setLidUOption(int index, int lidIndex, SM_LidUOptions param, int value);
-int  swmm_getLidUFluxRates(int index, int lidIndex, SM_LidLayer layerIndex, double *OUTPUT);
-int  swmm_getLidUResult(int index, int lidIndex, SM_LidResult type, double *OUTPUT);
+// int  swmm_getLinkType(int index, int *OUTPUT);
+// int  swmm_getLinkConnections(int index, int *OUTPUT, int *OUTPUT);
+// int  swmm_getLinkDirection(int index, signed char *value);
+// int  swmm_getLinkParam(int index, SM_LinkProperty parameter, double *OUTPUT);
+// int  swmm_setLinkParam(int index, SM_LinkProperty parameter, double value);
+// int  swmm_getLinkResult(int index, SM_LinkResult type, double *OUTPUT);
+// int  swmm_getLinkPollut(int index, SM_LinkPollut type, double **double_out, int *int_dim);
+// int  swmm_setLinkSetting(int index, double setting);
+// int  swmm_getLinkStats(int index, SM_LinkStats **in_out_dict);
+// int  swmm_getPumpStats(int index, SM_PumpStats **in_out_dict);
 
-int  swmm_getLidCOverflow(int lidControlIndex, int *OUTPUT);
-int  swmm_getLidCParam(int lidControlIndex, SM_LidLayer layerIndex, SM_LidUProperty param, double *OUTPUT);
-int  swmm_setLidCParam(int lidControlIndex, SM_LidLayer layerIndex, SM_LidUProperty param, double value);
+// int  swmm_getSubcatchOutConnection(int index, int *OUTPUT, int *OUTPUT);
+// int  swmm_getSubcatchParam(int index, SM_SubcProperty parameter, double *OUTPUT);
+// int  swmm_setSubcatchParam(int index, SM_SubcProperty parameter, double value);
+// int  swmm_getSubcatchResult(int index, SM_SubcResult type, double *OUTPUT);
+// int  swmm_getSubcatchPollut(int index, SM_SubcPollut type, double **double_out, int *int_dim);
+// int  swmm_getSubcatchStats(int index, SM_SubcatchStats **in_out_dict);
 
-int  swmm_getLidGResult(int index, SM_LidResult type, double *OUTPUT);
+// int  swmm_getLidUCount(int index, int *OUTPUT);
+// int  swmm_getLidUParam(int index, int lidIndex, SM_LidUProperty param, double *OUTPUT);
+// int  swmm_setLidUParam(int index, int lidIndex, SM_LidUProperty param, double value);
+// int  swmm_getLidUOption(int index, int lidIndex, SM_LidUOptions param, int *OUTPUT);
+// int  swmm_setLidUOption(int index, int lidIndex, SM_LidUOptions param, int value);
+// int  swmm_getLidUFluxRates(int index, int lidIndex, SM_LidLayer layerIndex, double *OUTPUT);
+// int  swmm_getLidUResult(int index, int lidIndex, SM_LidResult type, double *OUTPUT);
+
+// int  swmm_getLidCOverflow(int lidControlIndex, int *OUTPUT);
+// int  swmm_getLidCParam(int lidControlIndex, SM_LidLayer layerIndex, SM_LidUProperty param, double *OUTPUT);
+// int  swmm_setLidCParam(int lidControlIndex, SM_LidLayer layerIndex, SM_LidUProperty param, double value);
+
+// int  swmm_getLidGResult(int index, SM_LidResult type, double *OUTPUT);
 
 
 %exception;

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -28,7 +28,6 @@
 #include "toolkitAPI_enums.h"
 %}
 
-
 %include "stats_typemaps.i"
 
 
@@ -53,31 +52,31 @@
     int *hour,
     int *minute,
     int *second
-};
+}
 
 
 %apply double *OUTPUT {
     double *elapsedTime,
     double *value,
     double *result
-};
+}
 
 
 %apply float *OUTPUT {
     float *runoffErr,
     float *flowErr, 
     float *qualErr
-};
+}
 
 
 %apply signed char *OUTPUT {
     signed char *value
-};
+}
 
 
 %apply char *OUTPUT {
     char *condition
-};
+}
 
 
 %cstring_output_allocate(char **OUTCHAR, swmm_freeMemory(*$1));
@@ -87,7 +86,7 @@
     char **major, 
     char **minor, 
     char **patch
-};
+}
 
 
 /* TYPEMAPS FOR MEMORY MANAGEMNET OF DOUBLE ARRAYS */
@@ -100,7 +99,6 @@
 %typemap(argout) (double **double_out, int *int_dim) {
     if (*$1) {
       PyObject *o = PyList_New(*$2);
-      //double *temp = *$1;
       for(int i=0; i<*$2; i++) {
         PyList_SetItem(o, i, PyFloat_FromDouble(temp$argnum[i]));
       }
@@ -108,15 +106,16 @@
       swmm_freeMemory(*$1);
     }
 }
+
 %apply double **double_out {
     double **pollutArray
-};
+}
 %apply int *int_dim {
     int *length
 }
 %apply (double **double_out, int *int_dim) {
     (double **pollutArray, int *length)
-};
+}
 
 
 /* TYPEMAP FOR ENUMERATED TYPE INPUT ARGUMENTS */
@@ -154,6 +153,26 @@
     SM_LidUProperty,
     SM_LidUOptions,
     SM_LidResult
+}
+
+
+/* TYPEMAPS FOR ENUMERATED TYPE OUTPUT ARGUMENTS */
+%typemap(in, numinputs=0) EnumTypeOut * (int temp) {
+    $1 = ($1_type)&temp;
+}
+%typemap(argout) EnumTypeOut * {
+    char *temp = "$1_basetype";
+    PyObject *module = PyImport_ImportModule("swmm.toolkit.toolkit_enum");
+    PyObject *function = PyDict_GetItemString(PyModule_GetDict(module), (temp + 3));
+    if (PyCallable_Check(function)) {
+        PyObject *enum_out = PyObject_CallFunction(function, "i", *$1);
+        %append_output(enum_out);
+    }
+}
+%apply EnumTypeOut * {
+    SM_ObjectType *,
+    SM_NodeType *,
+    SM_LinkType *
 }
 
 
@@ -195,68 +214,6 @@
 %ignore swmm_freeMemory;
 
 %include "toolkitAPI.h"
-
-//// int  swmm_getAPIError(int ErrorCodeAPI, char **errorMsg);
-// int  swmm_getSimulationUnit(SM_Units type, int *OUTPUT);
-// int  swmm_project_findObject(SM_ObjectType type, char *id, int *OUTPUT);
-// int  swmm_countObjects(SM_ObjectType type, int *OUTPUT);
-// int  swmm_getSimulationDateTime(SM_TimePropety type, int *year, int *month, int *day, int *hour, int *minute, int *second);
-// int  swmm_setSimulationDateTime(SM_TimePropety timetype, int year, int month, int day, int hour, int minute, int second);
-// int  swmm_getSimulationAnalysisSetting(SM_SimOption type, int *OUTPUT);
-// int  swmm_getSimulationParam(SM_SimSetting type, double *OUTPUT);
-// int  swmm_getCurrentDateTime(int *year, int *month, int *day, int *hour, int *minute, int *second);
-// int  swmm_getSystemRoutingStats(SM_RoutingTotals** in_out_dict);
-// int  swmm_getSystemRunoffStats(SM_RunoffTotals** in_out_dict);
-
-// int  swmm_getObjectIndex(SM_ObjectType type, char *id, int *OUTPUT);
-// int  swmm_getObjectId(SM_ObjectType type, int index, char **id);
-
-// int  swmm_getGagePrecip(int index, SM_GagePrecip type, double *OUTPUT);
-// int  swmm_setGagePrecip(int index, double total_precip);
-
-// int  swmm_getNodeType(int index, int *OUTPUT);
-// int  swmm_getNodeParam(int index, SM_NodeProperty parameter, double *OUTPUT);
-// int  swmm_setNodeParam(int index, SM_NodeProperty parameter, double value);
-// int  swmm_getNodeResult(int index, SM_NodeResult type, double *OUTPUT);
-// int  swmm_getNodePollut(int index, SM_NodePollut type, double **double_out, int *int_dim);
-// int  swmm_getNodeTotalInflow(int index, double *OUTPUT);
-// int  swmm_setNodeInflow(int index, double flowrate);
-// int  swmm_setOutfallStage(int index, double stage);
-// int  swmm_getNodeStats(int index, SM_NodeStats **in_out_dict);
-// int  swmm_getStorageStats(int index, SM_StorageStats **in_out_dict);
-// int  swmm_getOutfallStats(int index, SM_OutfallStats **in_out_dict);
-
-// int  swmm_getLinkType(int index, int *OUTPUT);
-// int  swmm_getLinkConnections(int index, int *OUTPUT, int *OUTPUT);
-// int  swmm_getLinkDirection(int index, signed char *value);
-// int  swmm_getLinkParam(int index, SM_LinkProperty parameter, double *OUTPUT);
-// int  swmm_setLinkParam(int index, SM_LinkProperty parameter, double value);
-// int  swmm_getLinkResult(int index, SM_LinkResult type, double *OUTPUT);
-// int  swmm_getLinkPollut(int index, SM_LinkPollut type, double **double_out, int *int_dim);
-// int  swmm_setLinkSetting(int index, double setting);
-// int  swmm_getLinkStats(int index, SM_LinkStats **in_out_dict);
-// int  swmm_getPumpStats(int index, SM_PumpStats **in_out_dict);
-
-// int  swmm_getSubcatchOutConnection(int index, int *OUTPUT, int *OUTPUT);
-// int  swmm_getSubcatchParam(int index, SM_SubcProperty parameter, double *OUTPUT);
-// int  swmm_setSubcatchParam(int index, SM_SubcProperty parameter, double value);
-// int  swmm_getSubcatchResult(int index, SM_SubcResult type, double *OUTPUT);
-// int  swmm_getSubcatchPollut(int index, SM_SubcPollut type, double **double_out, int *int_dim);
-// int  swmm_getSubcatchStats(int index, SM_SubcatchStats **in_out_dict);
-
-// int  swmm_getLidUCount(int index, int *OUTPUT);
-// int  swmm_getLidUParam(int index, int lidIndex, SM_LidUProperty param, double *OUTPUT);
-// int  swmm_setLidUParam(int index, int lidIndex, SM_LidUProperty param, double value);
-// int  swmm_getLidUOption(int index, int lidIndex, SM_LidUOptions param, int *OUTPUT);
-// int  swmm_setLidUOption(int index, int lidIndex, SM_LidUOptions param, int value);
-// int  swmm_getLidUFluxRates(int index, int lidIndex, SM_LidLayer layerIndex, double *OUTPUT);
-// int  swmm_getLidUResult(int index, int lidIndex, SM_LidResult type, double *OUTPUT);
-
-// int  swmm_getLidCOverflow(int lidControlIndex, int *OUTPUT);
-// int  swmm_getLidCParam(int lidControlIndex, SM_LidLayer layerIndex, SM_LidUProperty param, double *OUTPUT);
-// int  swmm_setLidCParam(int lidControlIndex, SM_LidLayer layerIndex, SM_LidUProperty param, double value);
-
-// int  swmm_getLidGResult(int index, SM_LidResult type, double *OUTPUT);
 
 
 %exception;

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -45,7 +45,14 @@
 };
 
 %apply double *OUTPUT {
+    double *elapsedTime,
     double *value
+};
+
+%apply float *OUTPUT {
+    float *runoffErr,
+    float *flowErr, 
+    float *qualErr
 };
 
 %apply signed char *OUTPUT {
@@ -314,15 +321,8 @@
 }
 
 // CANONICAL API
-int  swmm_run(char *f1, char *f2, char *f3);
-int  swmm_open(char *f1, char *f2, char *f3);
-int  swmm_start(int saveFlag);
-int  swmm_step(double *OUTPUT);
-int  swmm_end(void);
-int  swmm_report(void);
-int  swmm_getMassBalErr(float *OUTPUT, float *OUTPUT, float *OUTPUT);
-int  swmm_close(void);
-int  swmm_getVersionInfo(char** major, char** minor, char** patch);
+%include "swmm5.h"
+
 
 
 // TOOLKIT API

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -24,11 +24,13 @@
 #define SWIG_FILE_WITH_INIT
 
 #include "swmm5.h"
-#include "toolkitAPI.h"
-#include "toolkitAPI_enums.h"
+#include "toolkit.h"
+#include "toolkit_enums.h"
+#include "toolkit_structs.h"
 %}
 
-%include "stats_typemaps.i"
+
+%include "stats_typemaps.i";
 
 
 /* TYPEMAP FOR IGNORING INT ERROR CODE RETURN VALUE */
@@ -212,10 +214,9 @@
 // TOOLKIT API
 %ignore swmm_run_cb;
 %ignore swmm_getAPIError;
-%ignore swmm_freeOutfallStats;
 %ignore swmm_freeMemory;
 
-%include "toolkitAPI.h"
+%include "toolkit.h"
 
 
 %exception;

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -203,6 +203,8 @@
 // CANONICAL API
 %ignore swmm_getError;
 %ignore swmm_getWarnings;
+%ignore swmm_IsOpenFlag;
+%ignore swmm_IsStartedFlag;
 
 %include "swmm5.h"
 

--- a/swmm-toolkit/src/swmm/toolkit/solver_rename.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver_rename.i
@@ -2,10 +2,11 @@
  *  solver_rename.i - Rename mapping for swmm-solver
  *
  *  Created:    2/26/2020
- *
- *  Author:     Michael E. Tryby
+ *  
+ *  Authors:    Michael E. Tryby
  *              US EPA - ORD/CESER
- *  Author:     Jennifer Wu
+ *
+ *              Jennifer Wu
  *              Xylem Inc.
  *
 */
@@ -20,7 +21,7 @@
 %rename(report)                                     swmm_report;
 %rename(get_mass_bal_err)                           swmm_getMassBalErr;
 %rename(close)                                      swmm_close;
-%rename(version)                                    swmm_getVersionInfo;
+%rename(version)                                    swmm_getVersion;
 
 //%rename(error_get_message)                          swmm_getAPIError;
 %rename(system_get_routing_stats)                   swmm_getSystemRoutingStats;

--- a/swmm-toolkit/src/swmm/toolkit/solver_rename.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver_rename.i
@@ -23,7 +23,7 @@
 %rename(close)                                      swmm_close;
 %rename(version)                                    swmm_getVersion;
 
-//%rename(error_get_message)                          swmm_getAPIError;
+%rename(version_info)                               swmm_getVersionInfo;
 %rename(system_get_routing_stats)                   swmm_getSystemRoutingStats;
 %rename(system_get_runoff_stats)                    swmm_getSystemRunoffStats;
 

--- a/swmm-toolkit/src/swmm/toolkit/solver_rename.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver_rename.i
@@ -24,8 +24,8 @@
 %rename(version)                                    swmm_getVersion;
 
 %rename(version_info)                               swmm_getVersionInfo;
-%rename(system_get_routing_stats)                   swmm_getSystemRoutingStats;
-%rename(system_get_runoff_stats)                    swmm_getSystemRunoffStats;
+%rename(system_get_routing_totals)                  swmm_getSystemRoutingTotals;
+%rename(system_get_runoff_totals)                   swmm_getSystemRunoffTotals;
 
 %rename(object_find)                                swmm_project_findObject;
 %rename(object_count)                               swmm_countObjects;

--- a/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
+++ b/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
@@ -88,14 +88,14 @@
 %rename (RoutingTotals) SM_RoutingTotals;
 %statsmaps(SM_RoutingTotals);
 %apply SM_RoutingTotals *out_stats {
-    SM_RoutingTotals *routingTot
+    SM_RoutingTotals *routingTotals
 }
 
 
 %rename (RunoffTotals) SM_RunoffTotals;
 %statsmaps(SM_RunoffTotals);
 %apply SM_RunoffTotals *out_stats {
-    SM_RunoffTotals *runoffTot
+    SM_RunoffTotals *runoffTotals
 }
 
 

--- a/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
+++ b/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
@@ -1,0 +1,171 @@
+
+
+
+%typemap(in, numinputs=0) SM_NodeStats **in_out_dict (SM_NodeStats *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_NodeStats **in_out_dict {
+    PyObject *o = PyDict_New();
+    PyMapping_SetItemString(o, "avgDepth", PyFloat_FromDouble((*$1)->avgDepth));
+    PyMapping_SetItemString(o, "maxDepth", PyFloat_FromDouble((*$1)->maxDepth));
+    PyMapping_SetItemString(o, "maxDepthDate", PyFloat_FromDouble((*$1)->maxDepthDate));
+    PyMapping_SetItemString(o, "maxRptDepth", PyFloat_FromDouble((*$1)->maxRptDepth));
+    PyMapping_SetItemString(o, "volFlooded", PyFloat_FromDouble((*$1)->volFlooded));
+    PyMapping_SetItemString(o, "timeFlooded", PyFloat_FromDouble((*$1)->timeFlooded));
+    PyMapping_SetItemString(o, "timeSurcharged", PyFloat_FromDouble((*$1)->timeSurcharged));
+    PyMapping_SetItemString(o, "timeCourantCritical", PyFloat_FromDouble((*$1)->timeCourantCritical));
+    PyMapping_SetItemString(o, "totLatFlow", PyFloat_FromDouble((*$1)->totLatFlow));
+    PyMapping_SetItemString(o, "maxLatFlow", PyFloat_FromDouble((*$1)->maxLatFlow));
+    PyMapping_SetItemString(o, "maxInflow", PyFloat_FromDouble((*$1)->maxInflow));
+    PyMapping_SetItemString(o, "maxOverflow", PyFloat_FromDouble((*$1)->maxOverflow));
+    PyMapping_SetItemString(o, "maxPondedVol", PyFloat_FromDouble((*$1)->maxPondedVol));
+    PyMapping_SetItemString(o, "maxInflowDate", PyFloat_FromDouble((*$1)->maxInflowDate));
+    PyMapping_SetItemString(o, "maxOverflowDate", PyFloat_FromDouble((*$1)->maxOverflowDate));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeMemory(*$1);
+}
+
+%typemap(in, numinputs=0) SM_StorageStats **in_out_dict (SM_StorageStats *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_StorageStats **in_out_dict {
+    PyObject *o = PyDict_New();
+    PyMapping_SetItemString(o, "initVol", PyFloat_FromDouble((*$1)->initVol));
+    PyMapping_SetItemString(o, "avgVol", PyFloat_FromDouble((*$1)->avgVol));
+    PyMapping_SetItemString(o, "maxVol", PyFloat_FromDouble((*$1)->maxVol));
+    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
+    PyMapping_SetItemString(o, "evapLosses", PyFloat_FromDouble((*$1)->evapLosses));
+    PyMapping_SetItemString(o, "exfilLosses", PyFloat_FromDouble((*$1)->exfilLosses));
+    PyMapping_SetItemString(o, "maxVolDate", PyFloat_FromDouble((*$1)->maxVolDate));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeMemory(*$1);
+}
+
+%typemap(in, numinputs=0) SM_OutfallStats **in_out_dict (SM_OutfallStats *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_OutfallStats **in_out_dict {
+    int length = sizeof((*$1)->totalLoad)/sizeof(double) + 1;
+    PyObject *loads = PyList_New(length);
+    PyObject *o = PyDict_New();
+    for(int i=0; i<length; i++) {
+      PyList_SetItem(loads, i, PyFloat_FromDouble(((*$1)->totalLoad)[i]));
+    }
+    PyMapping_SetItemString(o, "avgFlow", PyFloat_FromDouble((*$1)->avgFlow));
+    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
+    PyMapping_SetItemString(o, "loads", loads);
+    PyMapping_SetItemString(o, "totalPeriods", PyLong_FromLong((*$1)->totalPeriods));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeOutfallStats(*$1);
+    swmm_freeMemory(*$1);
+}
+
+%typemap(in, numinputs=0) SM_LinkStats **in_out_dict (SM_LinkStats *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_LinkStats **in_out_dict {
+    PyObject *o = PyDict_New();
+    PyObject *flowTime = PyDict_New();
+
+    PyMapping_SetItemString(flowTime, "DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[0]));
+    PyMapping_SetItemString(flowTime, "UP_DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[1]));
+    PyMapping_SetItemString(flowTime, "DN_DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[2]));
+    PyMapping_SetItemString(flowTime, "SUBCRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[3]));
+    PyMapping_SetItemString(flowTime, "SUPCRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[4]));
+    PyMapping_SetItemString(flowTime, "UP_CRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[5]));
+    PyMapping_SetItemString(flowTime, "DN_CRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[6]));
+    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
+    PyMapping_SetItemString(o, "maxFlowDate", PyFloat_FromDouble((*$1)->maxFlowDate));
+    PyMapping_SetItemString(o, "maxVeloc", PyFloat_FromDouble((*$1)->maxVeloc));
+    PyMapping_SetItemString(o, "maxDepth", PyFloat_FromDouble((*$1)->maxDepth));
+    PyMapping_SetItemString(o, "timeNormalFlow", PyFloat_FromDouble((*$1)->timeNormalFlow));
+    PyMapping_SetItemString(o, "timeInletControl", PyFloat_FromDouble((*$1)->timeInletControl));
+    PyMapping_SetItemString(o, "timeSurcharged", PyFloat_FromDouble((*$1)->timeSurcharged));
+    PyMapping_SetItemString(o, "timeFullUpstream", PyFloat_FromDouble((*$1)->timeFullUpstream));
+    PyMapping_SetItemString(o, "timeFullDnstream", PyFloat_FromDouble((*$1)->timeFullDnstream));
+    PyMapping_SetItemString(o, "timeFullFlow", PyFloat_FromDouble((*$1)->timeFullFlow));
+    PyMapping_SetItemString(o, "timeCapacityLimited", PyFloat_FromDouble((*$1)->timeCapacityLimited));
+    PyMapping_SetItemString(o, "timeCourantCritical", PyFloat_FromDouble((*$1)->timeCourantCritical));
+    PyMapping_SetItemString(o, "timeInFlowClass", flowTime);
+    PyMapping_SetItemString(o, "flowTurns", PyLong_FromLong((*$1)->flowTurns));
+    PyMapping_SetItemString(o, "flowTurnSign", PyLong_FromLong((*$1)->flowTurnSign));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeMemory(*$1);
+}
+
+%typemap(in, numinputs=0) SM_PumpStats **in_out_dict (SM_PumpStats *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_PumpStats **in_out_dict {
+    PyObject *o = PyDict_New();
+    PyMapping_SetItemString(o, "utilized", PyFloat_FromDouble((*$1)->utilized));
+    PyMapping_SetItemString(o, "minFlow", PyFloat_FromDouble((*$1)->minFlow));
+    PyMapping_SetItemString(o, "avgFlow", PyFloat_FromDouble((*$1)->avgFlow));
+    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
+    PyMapping_SetItemString(o, "volume", PyFloat_FromDouble((*$1)->volume));
+    PyMapping_SetItemString(o, "energy", PyFloat_FromDouble((*$1)->energy));
+    PyMapping_SetItemString(o, "offCurveLow", PyFloat_FromDouble((*$1)->offCurveLow));
+    PyMapping_SetItemString(o, "offCurveHigh", PyFloat_FromDouble((*$1)->offCurveHigh));
+    PyMapping_SetItemString(o, "startUps", PyLong_FromLong((*$1)->startUps));
+    PyMapping_SetItemString(o, "totalPeriods", PyLong_FromLong((*$1)->totalPeriods));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeMemory(*$1);
+}
+
+%typemap(in, numinputs=0) SM_SubcatchStats **in_out_dict (SM_SubcatchStats *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_SubcatchStats **in_out_dict {
+    PyObject *o = PyDict_New();
+    PyMapping_SetItemString(o, "precip", PyFloat_FromDouble((*$1)->precip));
+    PyMapping_SetItemString(o, "runon", PyFloat_FromDouble((*$1)->runon));
+    PyMapping_SetItemString(o, "evap", PyFloat_FromDouble((*$1)->evap));
+    PyMapping_SetItemString(o, "infil", PyFloat_FromDouble((*$1)->infil));
+    PyMapping_SetItemString(o, "runoff", PyFloat_FromDouble((*$1)->runoff));
+    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeMemory(*$1);
+}
+
+%typemap(in, numinputs=0) SM_RoutingTotals **in_out_dict (SM_RoutingTotals *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_RoutingTotals **in_out_dict {
+    PyObject *o = PyDict_New();
+    PyMapping_SetItemString(o, "dwInflow", PyFloat_FromDouble((*$1)->dwInflow));
+    PyMapping_SetItemString(o, "wwInflow", PyFloat_FromDouble((*$1)->wwInflow));
+    PyMapping_SetItemString(o, "gwInflow", PyFloat_FromDouble((*$1)->gwInflow));
+    PyMapping_SetItemString(o, "iiInflow", PyFloat_FromDouble((*$1)->iiInflow));
+    PyMapping_SetItemString(o, "exInflow", PyFloat_FromDouble((*$1)->exInflow));
+    PyMapping_SetItemString(o, "flooding", PyFloat_FromDouble((*$1)->flooding));
+    PyMapping_SetItemString(o, "outflow", PyFloat_FromDouble((*$1)->outflow));
+    PyMapping_SetItemString(o, "evapLoss", PyFloat_FromDouble((*$1)->evapLoss));
+    PyMapping_SetItemString(o, "seepLoss", PyFloat_FromDouble((*$1)->seepLoss));
+    PyMapping_SetItemString(o, "reacted", PyFloat_FromDouble((*$1)->reacted));
+    PyMapping_SetItemString(o, "initStorage", PyFloat_FromDouble((*$1)->initStorage));
+    PyMapping_SetItemString(o, "finalStorage", PyFloat_FromDouble((*$1)->finalStorage));
+    PyMapping_SetItemString(o, "pctError", PyFloat_FromDouble((*$1)->pctError));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeMemory(*$1);
+}
+
+%typemap(in, numinputs=0) SM_RunoffTotals **in_out_dict (SM_RunoffTotals *temp){
+    $1 = &temp;
+}
+%typemap(argout) SM_RunoffTotals **in_out_dict {
+    PyObject *o = PyDict_New();
+    PyMapping_SetItemString(o, "rainfall", PyFloat_FromDouble((*$1)->rainfall));
+    PyMapping_SetItemString(o, "evap", PyFloat_FromDouble((*$1)->evap));
+    PyMapping_SetItemString(o, "infil", PyFloat_FromDouble((*$1)->infil));
+    PyMapping_SetItemString(o, "runoff", PyFloat_FromDouble((*$1)->runoff));
+    PyMapping_SetItemString(o, "drains", PyFloat_FromDouble((*$1)->drains));
+    PyMapping_SetItemString(o, "runon", PyFloat_FromDouble((*$1)->runon));
+    PyMapping_SetItemString(o, "initStorage", PyFloat_FromDouble((*$1)->initStorage));
+    PyMapping_SetItemString(o, "finalStorage", PyFloat_FromDouble((*$1)->finalStorage));
+    PyMapping_SetItemString(o, "initSnowCover", PyFloat_FromDouble((*$1)->initSnowCover));
+    PyMapping_SetItemString(o, "finalSnowCover", PyFloat_FromDouble((*$1)->finalSnowCover));
+    PyMapping_SetItemString(o, "snowRemoved", PyFloat_FromDouble((*$1)->snowRemoved));
+    PyMapping_SetItemString(o, "Continuity Error", PyFloat_FromDouble((*$1)->pctError));
+    $result = SWIG_Python_AppendOutput($result, o);
+    swmm_freeMemory(*$1);
+}

--- a/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
+++ b/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
@@ -24,6 +24,10 @@
     $result = SWIG_Python_AppendOutput($result, o);
     swmm_freeMemory(*$1);
 }
+%apply SM_NodeStats **in_out_dict {
+    SM_NodeStats **nodeStats
+}
+
 
 %typemap(in, numinputs=0) SM_StorageStats **in_out_dict (SM_StorageStats *temp){
     $1 = &temp;
@@ -39,6 +43,9 @@
     PyMapping_SetItemString(o, "maxVolDate", PyFloat_FromDouble((*$1)->maxVolDate));
     $result = SWIG_Python_AppendOutput($result, o);
     swmm_freeMemory(*$1);
+}
+%apply SM_StorageStats **in_out_dict {
+    SM_StorageStats **storageStats
 }
 
 %typemap(in, numinputs=0) SM_OutfallStats **in_out_dict (SM_OutfallStats *temp){
@@ -59,6 +66,10 @@
     swmm_freeOutfallStats(*$1);
     swmm_freeMemory(*$1);
 }
+%apply SM_OutfallStats **in_out_dict {
+    SM_OutfallStats **outfallStats
+}
+
 
 %typemap(in, numinputs=0) SM_LinkStats **in_out_dict (SM_LinkStats *temp){
     $1 = &temp;
@@ -92,6 +103,10 @@
     $result = SWIG_Python_AppendOutput($result, o);
     swmm_freeMemory(*$1);
 }
+%apply SM_LinkStats **in_out_dict {
+    SM_LinkStats **linkStats
+}
+
 
 %typemap(in, numinputs=0) SM_PumpStats **in_out_dict (SM_PumpStats *temp){
     $1 = &temp;
@@ -111,6 +126,10 @@
     $result = SWIG_Python_AppendOutput($result, o);
     swmm_freeMemory(*$1);
 }
+%apply SM_PumpStats **in_out_dict {
+    SM_PumpStats **pumpStats
+}
+
 
 %typemap(in, numinputs=0) SM_SubcatchStats **in_out_dict (SM_SubcatchStats *temp){
     $1 = &temp;
@@ -126,6 +145,10 @@
     $result = SWIG_Python_AppendOutput($result, o);
     swmm_freeMemory(*$1);
 }
+%apply SM_SubcatchStats **in_out_dict {
+    SM_SubcatchStats **subcatchStats
+}
+
 
 %typemap(in, numinputs=0) SM_RoutingTotals **in_out_dict (SM_RoutingTotals *temp){
     $1 = &temp;
@@ -148,6 +171,10 @@
     $result = SWIG_Python_AppendOutput($result, o);
     swmm_freeMemory(*$1);
 }
+%apply SM_RoutingTotals **in_out_dict {
+    SM_RoutingTotals **routingTot
+}
+
 
 %typemap(in, numinputs=0) SM_RunoffTotals **in_out_dict (SM_RunoffTotals *temp){
     $1 = &temp;
@@ -168,4 +195,7 @@
     PyMapping_SetItemString(o, "Continuity Error", PyFloat_FromDouble((*$1)->pctError));
     $result = SWIG_Python_AppendOutput($result, o);
     swmm_freeMemory(*$1);
+}
+%apply SM_RunoffTotals **in_out_dict {
+    SM_RunoffTotals **runoffTot
 }

--- a/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
+++ b/swmm-toolkit/src/swmm/toolkit/stats_typemaps.i
@@ -1,201 +1,105 @@
 
 
 
-%typemap(in, numinputs=0) SM_NodeStats **in_out_dict (SM_NodeStats *temp){
-    $1 = &temp;
+%define %statsmaps(Type)
+%typemap(in, numinputs=0) Type *out_stats (Type *temp) {
+    temp = (Type *)calloc(1, sizeof(Type));
+    $1 = temp;
 }
-%typemap(argout) SM_NodeStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "avgDepth", PyFloat_FromDouble((*$1)->avgDepth));
-    PyMapping_SetItemString(o, "maxDepth", PyFloat_FromDouble((*$1)->maxDepth));
-    PyMapping_SetItemString(o, "maxDepthDate", PyFloat_FromDouble((*$1)->maxDepthDate));
-    PyMapping_SetItemString(o, "maxRptDepth", PyFloat_FromDouble((*$1)->maxRptDepth));
-    PyMapping_SetItemString(o, "volFlooded", PyFloat_FromDouble((*$1)->volFlooded));
-    PyMapping_SetItemString(o, "timeFlooded", PyFloat_FromDouble((*$1)->timeFlooded));
-    PyMapping_SetItemString(o, "timeSurcharged", PyFloat_FromDouble((*$1)->timeSurcharged));
-    PyMapping_SetItemString(o, "timeCourantCritical", PyFloat_FromDouble((*$1)->timeCourantCritical));
-    PyMapping_SetItemString(o, "totLatFlow", PyFloat_FromDouble((*$1)->totLatFlow));
-    PyMapping_SetItemString(o, "maxLatFlow", PyFloat_FromDouble((*$1)->maxLatFlow));
-    PyMapping_SetItemString(o, "maxInflow", PyFloat_FromDouble((*$1)->maxInflow));
-    PyMapping_SetItemString(o, "maxOverflow", PyFloat_FromDouble((*$1)->maxOverflow));
-    PyMapping_SetItemString(o, "maxPondedVol", PyFloat_FromDouble((*$1)->maxPondedVol));
-    PyMapping_SetItemString(o, "maxInflowDate", PyFloat_FromDouble((*$1)->maxInflowDate));
-    PyMapping_SetItemString(o, "maxOverflowDate", PyFloat_FromDouble((*$1)->maxOverflowDate));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
+%typemap(argout) Type *out_stats {
+    %append_output(SWIG_NewPointerObj(SWIG_as_voidptr(temp$argnum), $1_descriptor, 0));
 }
-%apply SM_NodeStats **in_out_dict {
-    SM_NodeStats **nodeStats
+%enddef
+
+
+%rename (NodeStats) SM_NodeStats;
+%statsmaps(SM_NodeStats);
+%apply SM_NodeStats *out_stats {
+    SM_NodeStats *nodeStats
 }
 
 
-%typemap(in, numinputs=0) SM_StorageStats **in_out_dict (SM_StorageStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_StorageStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "initVol", PyFloat_FromDouble((*$1)->initVol));
-    PyMapping_SetItemString(o, "avgVol", PyFloat_FromDouble((*$1)->avgVol));
-    PyMapping_SetItemString(o, "maxVol", PyFloat_FromDouble((*$1)->maxVol));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "evapLosses", PyFloat_FromDouble((*$1)->evapLosses));
-    PyMapping_SetItemString(o, "exfilLosses", PyFloat_FromDouble((*$1)->exfilLosses));
-    PyMapping_SetItemString(o, "maxVolDate", PyFloat_FromDouble((*$1)->maxVolDate));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-%apply SM_StorageStats **in_out_dict {
-    SM_StorageStats **storageStats
+%rename (StorageStats) SM_StorageStats;
+%statsmaps(SM_StorageStats);
+%apply SM_StorageStats *out_stats {
+    SM_StorageStats *storageStats
 }
 
-%typemap(in, numinputs=0) SM_OutfallStats **in_out_dict (SM_OutfallStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_OutfallStats **in_out_dict {
-    int length = sizeof((*$1)->totalLoad)/sizeof(double) + 1;
-    PyObject *loads = PyList_New(length);
-    PyObject *o = PyDict_New();
-    for(int i=0; i<length; i++) {
-      PyList_SetItem(loads, i, PyFloat_FromDouble(((*$1)->totalLoad)[i]));
+
+%rename (OutfallStats) SM_OutfallStats;
+/* PROVIDE CUSTOM CONSTRUCTOR/DECONSTRUCTOR */
+%nodefaultctor SM_OutfallStats;
+
+%extend SM_OutfallStats {
+    SM_OutfallStats(int num_pollut) {
+        SM_OutfallStats *s = (SM_OutfallStats *)calloc(1, sizeof(SM_OutfallStats));
+        if (num_pollut > 0)
+            s->totalLoad = (double *)calloc(num_pollut, sizeof(double));
+        return s;
     }
-    PyMapping_SetItemString(o, "avgFlow", PyFloat_FromDouble((*$1)->avgFlow));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "loads", loads);
-    PyMapping_SetItemString(o, "totalPeriods", PyLong_FromLong((*$1)->totalPeriods));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeOutfallStats(*$1);
-    swmm_freeMemory(*$1);
+
+    ~SM_OutfallStats(SM_OutfallStats *self) {
+        if (self != NULL)
+            free(self->totalLoad);
+        free(self);
+    }
+
+    double get_totalLoad(int index) {
+        return self->totalLoad[index];
+    }
 }
-%apply SM_OutfallStats **in_out_dict {
-    SM_OutfallStats **outfallStats
+
+%typemap(in, numinputs=0) SM_OutfallStats *out_outfall_stats (SM_OutfallStats *temp) {
+    int num_pollut;
+    swmm_countObjects(SM_POLLUT, &num_pollut);
+    temp = new_SM_OutfallStats(num_pollut);
+    $1 = temp;
+}
+%typemap(argout) SM_OutfallStats *out_outfall_stats {
+    %append_output(SWIG_NewPointerObj(SWIG_as_voidptr(temp$argnum), $1_descriptor, 0));
+}
+
+%apply SM_OutfallStats *out_outfall_stats {
+    SM_OutfallStats *outfallStats
 }
 
 
-%typemap(in, numinputs=0) SM_LinkStats **in_out_dict (SM_LinkStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_LinkStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyObject *flowTime = PyDict_New();
-
-    PyMapping_SetItemString(flowTime, "DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[0]));
-    PyMapping_SetItemString(flowTime, "UP_DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[1]));
-    PyMapping_SetItemString(flowTime, "DN_DRY", PyFloat_FromDouble(((*$1)->timeInFlowClass)[2]));
-    PyMapping_SetItemString(flowTime, "SUBCRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[3]));
-    PyMapping_SetItemString(flowTime, "SUPCRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[4]));
-    PyMapping_SetItemString(flowTime, "UP_CRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[5]));
-    PyMapping_SetItemString(flowTime, "DN_CRITICAL", PyFloat_FromDouble(((*$1)->timeInFlowClass)[6]));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "maxFlowDate", PyFloat_FromDouble((*$1)->maxFlowDate));
-    PyMapping_SetItemString(o, "maxVeloc", PyFloat_FromDouble((*$1)->maxVeloc));
-    PyMapping_SetItemString(o, "maxDepth", PyFloat_FromDouble((*$1)->maxDepth));
-    PyMapping_SetItemString(o, "timeNormalFlow", PyFloat_FromDouble((*$1)->timeNormalFlow));
-    PyMapping_SetItemString(o, "timeInletControl", PyFloat_FromDouble((*$1)->timeInletControl));
-    PyMapping_SetItemString(o, "timeSurcharged", PyFloat_FromDouble((*$1)->timeSurcharged));
-    PyMapping_SetItemString(o, "timeFullUpstream", PyFloat_FromDouble((*$1)->timeFullUpstream));
-    PyMapping_SetItemString(o, "timeFullDnstream", PyFloat_FromDouble((*$1)->timeFullDnstream));
-    PyMapping_SetItemString(o, "timeFullFlow", PyFloat_FromDouble((*$1)->timeFullFlow));
-    PyMapping_SetItemString(o, "timeCapacityLimited", PyFloat_FromDouble((*$1)->timeCapacityLimited));
-    PyMapping_SetItemString(o, "timeCourantCritical", PyFloat_FromDouble((*$1)->timeCourantCritical));
-    PyMapping_SetItemString(o, "timeInFlowClass", flowTime);
-    PyMapping_SetItemString(o, "flowTurns", PyLong_FromLong((*$1)->flowTurns));
-    PyMapping_SetItemString(o, "flowTurnSign", PyLong_FromLong((*$1)->flowTurnSign));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-%apply SM_LinkStats **in_out_dict {
-    SM_LinkStats **linkStats
+%rename (LinkStats) SM_LinkStats;
+%statsmaps(SM_LinkStats);
+%apply SM_LinkStats *out_stats {
+    SM_LinkStats *linkStats
 }
 
 
-%typemap(in, numinputs=0) SM_PumpStats **in_out_dict (SM_PumpStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_PumpStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "utilized", PyFloat_FromDouble((*$1)->utilized));
-    PyMapping_SetItemString(o, "minFlow", PyFloat_FromDouble((*$1)->minFlow));
-    PyMapping_SetItemString(o, "avgFlow", PyFloat_FromDouble((*$1)->avgFlow));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    PyMapping_SetItemString(o, "volume", PyFloat_FromDouble((*$1)->volume));
-    PyMapping_SetItemString(o, "energy", PyFloat_FromDouble((*$1)->energy));
-    PyMapping_SetItemString(o, "offCurveLow", PyFloat_FromDouble((*$1)->offCurveLow));
-    PyMapping_SetItemString(o, "offCurveHigh", PyFloat_FromDouble((*$1)->offCurveHigh));
-    PyMapping_SetItemString(o, "startUps", PyLong_FromLong((*$1)->startUps));
-    PyMapping_SetItemString(o, "totalPeriods", PyLong_FromLong((*$1)->totalPeriods));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-%apply SM_PumpStats **in_out_dict {
-    SM_PumpStats **pumpStats
+%rename (PumpStats) SM_PumpStats;
+%statsmaps(SM_PumpStats);
+%apply SM_PumpStats *out_stats {
+    SM_PumpStats *pumpStats
 }
 
 
-%typemap(in, numinputs=0) SM_SubcatchStats **in_out_dict (SM_SubcatchStats *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_SubcatchStats **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "precip", PyFloat_FromDouble((*$1)->precip));
-    PyMapping_SetItemString(o, "runon", PyFloat_FromDouble((*$1)->runon));
-    PyMapping_SetItemString(o, "evap", PyFloat_FromDouble((*$1)->evap));
-    PyMapping_SetItemString(o, "infil", PyFloat_FromDouble((*$1)->infil));
-    PyMapping_SetItemString(o, "runoff", PyFloat_FromDouble((*$1)->runoff));
-    PyMapping_SetItemString(o, "maxFlow", PyFloat_FromDouble((*$1)->maxFlow));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-%apply SM_SubcatchStats **in_out_dict {
-    SM_SubcatchStats **subcatchStats
+%rename (SubcatchStats) SM_SubcatchStats;
+%statsmaps(SM_SubcatchStats);
+%apply SM_SubcatchStats *out_stats {
+    SM_SubcatchStats *subcatchStats
 }
 
 
-%typemap(in, numinputs=0) SM_RoutingTotals **in_out_dict (SM_RoutingTotals *temp){
-    $1 = &temp;
-}
-%typemap(argout) SM_RoutingTotals **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "dwInflow", PyFloat_FromDouble((*$1)->dwInflow));
-    PyMapping_SetItemString(o, "wwInflow", PyFloat_FromDouble((*$1)->wwInflow));
-    PyMapping_SetItemString(o, "gwInflow", PyFloat_FromDouble((*$1)->gwInflow));
-    PyMapping_SetItemString(o, "iiInflow", PyFloat_FromDouble((*$1)->iiInflow));
-    PyMapping_SetItemString(o, "exInflow", PyFloat_FromDouble((*$1)->exInflow));
-    PyMapping_SetItemString(o, "flooding", PyFloat_FromDouble((*$1)->flooding));
-    PyMapping_SetItemString(o, "outflow", PyFloat_FromDouble((*$1)->outflow));
-    PyMapping_SetItemString(o, "evapLoss", PyFloat_FromDouble((*$1)->evapLoss));
-    PyMapping_SetItemString(o, "seepLoss", PyFloat_FromDouble((*$1)->seepLoss));
-    PyMapping_SetItemString(o, "reacted", PyFloat_FromDouble((*$1)->reacted));
-    PyMapping_SetItemString(o, "initStorage", PyFloat_FromDouble((*$1)->initStorage));
-    PyMapping_SetItemString(o, "finalStorage", PyFloat_FromDouble((*$1)->finalStorage));
-    PyMapping_SetItemString(o, "pctError", PyFloat_FromDouble((*$1)->pctError));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-%apply SM_RoutingTotals **in_out_dict {
-    SM_RoutingTotals **routingTot
+%rename (RoutingTotals) SM_RoutingTotals;
+%statsmaps(SM_RoutingTotals);
+%apply SM_RoutingTotals *out_stats {
+    SM_RoutingTotals *routingTot
 }
 
 
-%typemap(in, numinputs=0) SM_RunoffTotals **in_out_dict (SM_RunoffTotals *temp){
-    $1 = &temp;
+%rename (RunoffTotals) SM_RunoffTotals;
+%statsmaps(SM_RunoffTotals);
+%apply SM_RunoffTotals *out_stats {
+    SM_RunoffTotals *runoffTot
 }
-%typemap(argout) SM_RunoffTotals **in_out_dict {
-    PyObject *o = PyDict_New();
-    PyMapping_SetItemString(o, "rainfall", PyFloat_FromDouble((*$1)->rainfall));
-    PyMapping_SetItemString(o, "evap", PyFloat_FromDouble((*$1)->evap));
-    PyMapping_SetItemString(o, "infil", PyFloat_FromDouble((*$1)->infil));
-    PyMapping_SetItemString(o, "runoff", PyFloat_FromDouble((*$1)->runoff));
-    PyMapping_SetItemString(o, "drains", PyFloat_FromDouble((*$1)->drains));
-    PyMapping_SetItemString(o, "runon", PyFloat_FromDouble((*$1)->runon));
-    PyMapping_SetItemString(o, "initStorage", PyFloat_FromDouble((*$1)->initStorage));
-    PyMapping_SetItemString(o, "finalStorage", PyFloat_FromDouble((*$1)->finalStorage));
-    PyMapping_SetItemString(o, "initSnowCover", PyFloat_FromDouble((*$1)->initSnowCover));
-    PyMapping_SetItemString(o, "finalSnowCover", PyFloat_FromDouble((*$1)->finalSnowCover));
-    PyMapping_SetItemString(o, "snowRemoved", PyFloat_FromDouble((*$1)->snowRemoved));
-    PyMapping_SetItemString(o, "Continuity Error", PyFloat_FromDouble((*$1)->pctError));
-    $result = SWIG_Python_AppendOutput($result, o);
-    swmm_freeMemory(*$1);
-}
-%apply SM_RunoffTotals **in_out_dict {
-    SM_RunoffTotals **runoffTot
-}
+
+
+/* WRAP PUBLIC STRUCTURES AND GENERATE GETTERS */
+%immutable;
+%include "toolkit_structs.h"
+%noimmutable;

--- a/swmm-toolkit/src/swmm/toolkit/toolkit_enum.py
+++ b/swmm-toolkit/src/swmm/toolkit/toolkit_enum.py
@@ -32,6 +32,23 @@ class ConcUnits(Enum, start=0):
     COUNT
     NONE
 
+class ObjectType(Enum, start=0):
+    GAGE
+    SUBCATCH
+    NODE
+    LINK
+    POLLUT
+    LANDUSE
+    TIMEPATTERN
+    CURVE
+    TSERIES
+    CONTROL
+    TRANSECT
+    AQUIFER
+    UNITHYD
+    SNOWMELT
+    SHAPE
+    LID
 
 class NodeType(Enum, start=0):
     JUNCTION
@@ -133,27 +150,7 @@ class BaseUnits(Enum, start = 1):
 
 #
 # Solver Toolkit API Enums
-#
-
-class ObjectProperty(Enum, start=0):
-    GAGE
-    SUBCATCH 
-    NODE
-    LINK  
-    POLLUT
-    LAND_USE 
-    TIME_PATTERN
-    CURVE
-    TIMESERIES   
-    CONTROL
-    TRANSECT
-    AQUIFER
-    UNIT_HYD  
-    SNOW_MELT
-    SHAPE
-    LID
-
-    
+#    
 class TimeProperty(Enum, start=0):
     START_DATE
     END_DATE

--- a/swmm-toolkit/tests/test_solver.py
+++ b/swmm-toolkit/tests/test_solver.py
@@ -98,7 +98,7 @@ def test_step(handle):
 
 
 def test_version(handle):
-    major, minor, patch = solver.version()
+    major, minor, patch = solver.version_info()
     print(major, minor, patch)
     assert major == '5'
     
@@ -111,11 +111,11 @@ def test_simulation_unit(handle):
 
 
 def test_object_find(handle):
-    rg_index = solver.object_find(toolkit_enum.ObjectProperty.GAGE, 'RG1')
-    sub_index_0 = solver.object_find(toolkit_enum.ObjectProperty.SUBCATCH, '2')
-    sub_index_1 = solver.object_find(toolkit_enum.ObjectProperty.SUBCATCH, '3')
-    node_index = solver.object_find(toolkit_enum.ObjectProperty.NODE, '24')
-    link_index = solver.object_find(toolkit_enum.ObjectProperty.LINK, '16')
+    rg_index = solver.object_find(toolkit_enum.ObjectType.GAGE, 'RG1')
+    sub_index_0 = solver.object_find(toolkit_enum.ObjectType.SUBCATCH, '2')
+    sub_index_1 = solver.object_find(toolkit_enum.ObjectType.SUBCATCH, '3')
+    node_index = solver.object_find(toolkit_enum.ObjectType.NODE, '24')
+    link_index = solver.object_find(toolkit_enum.ObjectType.LINK, '16')
     assert rg_index == 0
     assert sub_index_0 == 0
     assert sub_index_1 == 1
@@ -125,14 +125,14 @@ def test_object_find(handle):
 
 def test_error_message_handling(handle):
     with pytest.raises(Exception) as exc_info:
-        solver.object_find(toolkit_enum.ObjectProperty.SUBCATCH, 'sloth')
+        solver.object_find(toolkit_enum.ObjectType.SUBCATCH, 'sloth')
 
     assert 'API Key Error: Object index out of Bounds' in str(exc_info.value)
 
 
 def test_object_count(handle):
-    rg_count = solver.object_count(toolkit_enum.ObjectProperty.GAGE)
-    sub_count = solver.object_count(toolkit_enum.ObjectProperty.SUBCATCH)
+    rg_count = solver.object_count(toolkit_enum.ObjectType.GAGE)
+    sub_count = solver.object_count(toolkit_enum.ObjectType.SUBCATCH)
     assert rg_count == 1
     assert sub_count == 8
 
@@ -186,22 +186,22 @@ def test_simulation_parameter(handle):
 
 
 def test_object_get_index(handle):
-    node_index = solver.object_get_index(toolkit_enum.ObjectProperty.NODE, '6')
-    sub_index = solver.object_get_index(toolkit_enum.ObjectProperty.SUBCATCH, '20')
+    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, '6')
+    sub_index = solver.object_get_index(toolkit_enum.ObjectType.SUBCATCH, '20')
 
     assert node_index == -1
     assert sub_index == -1
 
-    node_index = solver.object_get_index(toolkit_enum.ObjectProperty.NODE, '20')
-    sub_index = solver.object_get_index(toolkit_enum.ObjectProperty.SUBCATCH, '6')
+    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, '20')
+    sub_index = solver.object_get_index(toolkit_enum.ObjectType.SUBCATCH, '6')
 
     assert node_index == 8
     assert sub_index == 5
 
 
 def test_object_get_id(handle):
-    node_name = solver.object_get_id(toolkit_enum.ObjectProperty.NODE, 8)
-    sub_name = solver.object_get_id(toolkit_enum.ObjectProperty.SUBCATCH, 5)
+    node_name = solver.object_get_id(toolkit_enum.ObjectType.NODE, 8)
+    sub_name = solver.object_get_id(toolkit_enum.ObjectType.SUBCATCH, 5)
     assert node_name == '20'
     assert sub_name == '6'
 
@@ -226,7 +226,7 @@ def test_get_runoff_stats(run_sim):
 
 def test_link_get_type(handle):
     link_type = solver.link_get_type(2)
-    assert link_type == toolkit_enum.LinkType.CONDUIT.value
+    assert link_type == toolkit_enum.LinkType.CONDUIT
 
 
 def test_link_get_connections(handle):
@@ -340,7 +340,7 @@ def test_link_get_stats(run_sim):
 
 
 def test_pump_get_stats(run_sim):
-    index = solver.object_get_index(toolkit_enum.ObjectProperty.LINK, 'P1')
+    index = solver.object_get_index(toolkit_enum.ObjectType.LINK, 'P1')
     while True:
         time = solver.step()
         if time == 0:
@@ -351,10 +351,10 @@ def test_pump_get_stats(run_sim):
 
 def test_node_get_type(handle):
     node_type = solver.node_get_type(8)
-    assert node_type == toolkit_enum.NodeType.JUNCTION.value
-    node_index = solver.object_get_index(toolkit_enum.ObjectProperty.NODE, '18')
+    assert node_type == toolkit_enum.NodeType.JUNCTION
+    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, '18')
     node_type = solver.node_get_type(node_index)
-    assert node_type == toolkit_enum.NodeType.OUTFALL.value
+    assert node_type == toolkit_enum.NodeType.OUTFALL
 
 
 def test_node_param(handle):
@@ -461,7 +461,7 @@ def test_node_get_stats(run_sim):
 
 
 def test_storage_get_stats(run_sim):
-    node_index = solver.object_get_index(toolkit_enum.ObjectProperty.NODE, 'SU1')
+    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, 'SU1')
     while True:
         time = solver.step()
         if time == 0:
@@ -472,7 +472,7 @@ def test_storage_get_stats(run_sim):
 
 
 def test_outfall_get_stats(run_sim):
-    node_index = solver.object_get_index(toolkit_enum.ObjectProperty.NODE, '18')
+    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, '18')
     while True:
         time = solver.step()
         if time == 0:
@@ -516,16 +516,17 @@ def test_subcatch_param(handle):
 
 def test_subcatch_get_connection(handle):
     object_type, object_index = solver.subcatch_get_connection(0)
-    assert object_type == toolkit_enum.ObjectProperty.NODE.value
+    assert object_type == toolkit_enum.ObjectType.NODE
     assert object_index == 1
+
     object_type, object_index = solver.subcatch_get_connection(1)
-    assert object_type == toolkit_enum.ObjectProperty.NODE.value
+    assert object_type == toolkit_enum.ObjectType.NODE
     assert object_index == 2
     object_type, object_index = solver.subcatch_get_connection(2)
-    assert object_type == toolkit_enum.ObjectProperty.NODE.value
+    assert object_type == toolkit_enum.ObjectType.NODE
     assert object_index == 0
     object_type, object_index = solver.subcatch_get_connection(3)
-    assert object_type == toolkit_enum.ObjectProperty.NODE.value
+    assert object_type == toolkit_enum.ObjectType.NODE
     assert object_index == 10
 
 
@@ -649,7 +650,7 @@ def test_lid_usage_get_result(run_lid_sim):
 
 
 def test_lid_group_get_result(run_lid_sim):
-    index = solver.object_get_index(toolkit_enum.ObjectProperty.SUBCATCH, 'wBC')
+    index = solver.object_get_index(toolkit_enum.ObjectType.SUBCATCH, 'wBC')
     while True:
         time = solver.step()
         if time == 0:

--- a/swmm-toolkit/tests/test_solver.py
+++ b/swmm-toolkit/tests/test_solver.py
@@ -450,38 +450,6 @@ def test_outfall_set_stage(run_sim):
     solver.step()
 
 
-def test_node_get_stats(run_sim):
-    while True:
-        time = solver.step()
-        if time == 0:
-            break
-
-    node_stats = solver.node_get_stats(5)
-    node_stats['maxDepth'] == pytest.approx(1.15, 0.1)
-
-
-def test_storage_get_stats(run_sim):
-    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, 'SU1')
-    while True:
-        time = solver.step()
-        if time == 0:
-            break
-
-    stor_stats = solver.storage_get_stats(node_index)
-    stor_stats['avgVol'] == pytest.approx(0, 0.1)
-
-
-def test_outfall_get_stats(run_sim):
-    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, '18')
-    while True:
-        time = solver.step()
-        if time == 0:
-            break
-
-    stats = solver.outfall_get_stats(node_index)
-    assert isinstance(stats['loads'], list)
-
-
 def test_subcatch_param(handle):
     width = solver.subcatch_get_parameter(0, toolkit_enum.SubcatchProperty.WIDTH)
     area = solver.subcatch_get_parameter(0, toolkit_enum.SubcatchProperty.AREA)

--- a/swmm-toolkit/tests/test_solver.py
+++ b/swmm-toolkit/tests/test_solver.py
@@ -206,24 +206,6 @@ def test_object_get_id(handle):
     assert sub_name == '6'
 
 
-def test_get_routing_stats(run_sim):
-    while True:
-        time = solver.step()
-        if time == 0:
-            break
-
-    stats = solver.system_get_routing_stats()
-
-
-def test_get_runoff_stats(run_sim):
-    while True:
-        time = solver.step()
-        if time == 0:
-            break
-
-    stats = solver.system_get_runoff_stats()
-
-
 def test_link_get_type(handle):
     link_type = solver.link_get_type(2)
     assert link_type == toolkit_enum.LinkType.CONDUIT

--- a/swmm-toolkit/tests/test_stats.py
+++ b/swmm-toolkit/tests/test_stats.py
@@ -59,3 +59,15 @@ def test_outfall_stats(before_end):
 
     stats = solver.outfall_get_stats(index)
     assert stats.totalLoad != None
+
+
+def test_get_routing_totals(before_end):
+
+    stats = solver.system_get_routing_totals()
+    assert stats != None
+
+
+def test_get_runoff_totals(before_end):
+
+    stats = solver.system_get_runoff_totals()
+    assert stats != None

--- a/swmm-toolkit/tests/test_stats.py
+++ b/swmm-toolkit/tests/test_stats.py
@@ -1,0 +1,61 @@
+
+import os
+import ctypes
+
+import pytest
+import numpy 
+
+from swmm.toolkit import solver, toolkit_enum
+
+
+DATA_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
+INPUT_FILE_EXAMPLE_1 = os.path.join(DATA_PATH, 'test_Example1.inp')
+REPORT_FILE_TEST_1 = os.path.join(DATA_PATH, 'temp_Example.rpt')
+OUTPUT_FILE_TEST_1 = os.path.join(DATA_PATH, 'temp_Example.out')
+
+
+@pytest.fixture()
+def before_end(request):
+    solver.open(INPUT_FILE_EXAMPLE_1, REPORT_FILE_TEST_1, OUTPUT_FILE_TEST_1)
+    solver.start(0)
+    
+    while True:
+        time = solver.step()
+        if time == 0:
+            break
+    
+    def close():
+        solver.end()
+        solver.close()
+
+    request.addfinalizer(close)
+
+
+def test_node_get_stats(before_end):
+    while True:
+        time = solver.step()
+        if time == 0:
+            break
+
+    node_stats = solver.node_get_stats(5)
+    assert node_stats.maxDepth  == pytest.approx(1.15, 0.1)
+
+
+def test_storage_get_stats(before_end):
+    node_index = solver.object_get_index(toolkit_enum.ObjectType.NODE, 'SU1')
+    while True:
+        time = solver.step()
+        if time == 0:
+            break
+
+    stor_stats = solver.storage_get_stats(node_index)
+    assert stor_stats.avgVol == pytest.approx(0, 0.1)
+
+
+def test_outfall_stats(before_end):
+    id = '18'
+
+    index = solver.object_get_index(toolkit_enum.ObjectType.NODE, id)
+
+    stats = solver.outfall_get_stats(index)
+    assert stats.totalLoad != None


### PR DESCRIPTION
This PR accomplishes the following: 
 - Refactors `solver.i` to eliminate duplication of API function declarations
 - Refactors `solver.i` to generalize type maps for exporting stats structs
 - Refactors double array type maps to apply properly
 - Adds type map for enum output variables
 - Isolate type maps for wrapping stats
 - Renames ObjectProperty enum to ObjectType
 - Refactors swmm-solver carrying over any necessary changes