### PR TITLE
fix to get add_dll_directory working on conda-built python distributions

### DIFF
--- a/nrtest-swmm/nrtest_swmm/output_reader.py
+++ b/nrtest-swmm/nrtest_swmm/output_reader.py
@@ -18,7 +18,7 @@ generator.
 from itertools import islice
 
 # project import
-from swmm.toolkit import output, output_enum
+from swmm.toolkit import output, shared_enum
 
 
 def output_generator(path_ref):
@@ -40,7 +40,7 @@ def output_generator(path_ref):
     with OutputReader(path_ref) as reader:
 
         for period_index in range(0, reader.report_periods()):
-            for element_type in islice(output_enum.ElementType, 4):
+            for element_type in islice(shared_enum.ElementType, 4):
                 for element_index in range(0, reader.element_count(element_type)):
 
                     yield (reader.element_result(element_type, period_index, element_index),
@@ -57,10 +57,10 @@ class OutputReader():
         self.handle = None
         self.count = None
         self.get_element_result = {
-            output_enum.ElementType.SUBCATCH: output.get_subcatch_result,
-            output_enum.ElementType.NODE: output.get_node_result,
-            output_enum.ElementType.LINK: output.get_link_result,
-            output_enum.ElementType.SYSTEM: output.get_system_result
+            shared_enum.ElementType.SUBCATCH: output.get_subcatch_result,
+            shared_enum.ElementType.NODE: output.get_node_result,
+            shared_enum.ElementType.LINK: output.get_link_result,
+            shared_enum.ElementType.SYSTEM: output.get_system_result
         }
 
     def __enter__(self):
@@ -73,7 +73,7 @@ class OutputReader():
         output.close(self.handle)
 
     def report_periods(self):
-        return output.get_times(self.handle, output_enum.Time.NUM_PERIODS)
+        return output.get_times(self.handle, shared_enum.Time.NUM_PERIODS)
 
     def element_count(self, element_type):
         return self.count[element_type]

--- a/swmm-toolkit/src/swmm/toolkit/__init__.py
+++ b/swmm-toolkit/src/swmm/toolkit/__init__.py
@@ -29,6 +29,7 @@ __status__  = "Beta"
 
 import os
 import platform
+import sys
 
 
 # Adds directory containing swmm libraries to path
@@ -36,6 +37,8 @@ if platform.system() == "Windows":
     libdir = os.path.join(os.path.dirname(__file__), "../../swmm_toolkit")
 
     if hasattr(os, 'add_dll_directory'):
-        os.add_dll_directory(libdir)
+       if 'conda' in sys.version:
+           os.environ['CONDA_DLL_SEARCH_MODIFICATION_ENABLE']="1"
+       os.add_dll_directory(libdir)
     else:
         os.environ["PATH"] = libdir + ";" + os.environ["PATH"]


### PR DESCRIPTION
Addresses #79 . 

I also revised the nrtest-swmm output_reader.py file to import shared_enum rather than output_enum since the file was renamed and the import no longer works.