### PR TITLE
Wrapper for extracting time series from SWMM output file

### DIFF
--- a/swmm-toolkit/tests/test_wrappers.py
+++ b/swmm-toolkit/tests/test_wrappers.py
@@ -7,7 +7,7 @@ from swmm.toolkit import shared_enum
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(HERE,'..','wrappers'))
-from utils import get_ts_from_model
+from utils import get_ts_from_model, get_system_ts_from_model
 DATA_PATH = os.path.join(HERE, 'data')
 OUTPUT_FILE_EXAMPLE1 = os.path.join(DATA_PATH, 'test_Example1.out')
 CONDUIT_IDs = ['15', '6']
@@ -43,4 +43,21 @@ def test_get_ts_from_model_node():
 
     df_1 = df.iloc[0:3]
     df_2 = pd.DataFrame(df_dict)
+    pd.testing.assert_frame_equal(df_1, df_2)
+
+def test_get_system_ts_from_model():
+    # test rainfall
+    df = get_system_ts_from_model(OUTPUT_FILE_EXAMPLE1, system_variable='rainfall')
+
+    df_1 = df.iloc[0:3]
+    df_2 = pd.DataFrame([0.25,0.50,0.80], 
+    index=[pd.Timestamp('1998-01-01 00:00:00'),pd.Timestamp('1998-01-01 01:00:00'),pd.Timestamp('1998-01-01 02:00:00')])
+    pd.testing.assert_frame_equal(df_1, df_2)
+
+    # test temperature
+    df = get_system_ts_from_model(OUTPUT_FILE_EXAMPLE1, system_variable='temperature')
+
+    df_1 = df.iloc[0:3]
+    df_2 = pd.DataFrame([70.0,70.0,70.0], 
+    index=[pd.Timestamp('1998-01-01 00:00:00'),pd.Timestamp('1998-01-01 01:00:00'),pd.Timestamp('1998-01-01 02:00:00')])
     pd.testing.assert_frame_equal(df_1, df_2)

--- a/swmm-toolkit/tests/test_wrappers.py
+++ b/swmm-toolkit/tests/test_wrappers.py
@@ -1,0 +1,46 @@
+
+import os, sys
+import pytest
+import pandas as pd
+
+from swmm.toolkit import shared_enum
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(HERE,'..','wrappers'))
+from utils import get_ts_from_model
+DATA_PATH = os.path.join(HERE, 'data')
+OUTPUT_FILE_EXAMPLE1 = os.path.join(DATA_PATH, 'test_Example1.out')
+CONDUIT_IDs = ['15', '6']
+NODE_IDs = ['21', '24']
+
+
+
+def test_get_ts_from_model_link():
+    df = get_ts_from_model(OUTPUT_FILE_EXAMPLE1, CONDUIT_IDs, shared_enum.LinkAttribute.FLOW_RATE, 
+                        object_type='link')
+
+    df_dict = {'15': {pd.Timestamp('1998-01-01 00:00:00'): 0.0, 
+    pd.Timestamp('1998-01-01 01:00:00'): 5.613319396972656, 
+    pd.Timestamp('1998-01-01 02:00:00'): 11.292198181152344}, 
+    '6': {pd.Timestamp('1998-01-01 00:00:00'): 0.0, 
+    pd.Timestamp('1998-01-01 01:00:00'): 2.4767236709594727, 
+    pd.Timestamp('1998-01-01 02:00:00'): 4.6317620277404785}}
+
+    df_1 = df.iloc[0:3]
+    df_2 = pd.DataFrame(df_dict)
+    pd.testing.assert_frame_equal(df_1, df_2)
+
+def test_get_ts_from_model_node():
+    df = get_ts_from_model(OUTPUT_FILE_EXAMPLE1, NODE_IDs, shared_enum.NodeAttribute.TOTAL_INFLOW, 
+                        object_type='node')
+
+    df_dict = {'21': {pd.Timestamp('1998-01-01 00:00:00'): 0.0, 
+    pd.Timestamp('1998-01-01 01:00:00'): 2.577545166015625, 
+    pd.Timestamp('1998-01-01 02:00:00'): 4.874996662139893}, 
+    '24': {pd.Timestamp('1998-01-01 00:00:00'): 0.0, 
+    pd.Timestamp('1998-01-01 01:00:00'): 5.915661334991455, 
+    pd.Timestamp('1998-01-01 02:00:00'): 11.939848899841309}}
+
+    df_1 = df.iloc[0:3]
+    df_2 = pd.DataFrame(df_dict)
+    pd.testing.assert_frame_equal(df_1, df_2)

--- a/swmm-toolkit/wrappers/utils.py
+++ b/swmm-toolkit/wrappers/utils.py
@@ -1,0 +1,88 @@
+'''
+Created on Fri Jun 18 09:55:14 2021
+
+@author: Mehmet B. Ercan 
+'''
+
+
+
+from swmm.toolkit import output, shared_enum
+import julian, datetime
+import pandas as pd
+
+
+def find_linkid_index(handle,link_id):
+    i = 0
+    while True:
+        if output.get_elem_name(handle, shared_enum.ElementType.LINK, i) == link_id:
+            break
+        i+=1
+    return i 
+
+def find_nodeid_index(handle,node_id):
+    i = 0
+    while True:
+        if output.get_elem_name(handle, shared_enum.ElementType.NODE, i) == node_id:
+            break
+        i+=1
+    return i 
+
+def get_date_time_array(handle):
+    report_start_date_time = output.get_start_date(handle)
+    num_steps = output.get_times(handle, shared_enum.Time.NUM_PERIODS)
+    report_step = output.get_times(handle, shared_enum.Time.REPORT_STEP)
+    date_times = []
+    for ind in range(num_steps):
+        if ind == 0:
+            datetime_dbl = report_start_date_time + (ind * 1.0 * report_step / 86400.0) + 2415018.5
+            date_time_0 = julian.from_jd(datetime_dbl, 'jd')
+            date_times.append(date_time_0)
+        else:
+            date_time = date_time_0 + datetime.timedelta(seconds=report_step)*ind
+            date_times.append(date_time)
+    return date_times, num_steps
+
+
+def get_ts_from_model(swmm_out, object_ids, attribute, object_type='link'):
+    '''
+    Parameters (---- it only works with link and nodes for now ----)
+    ----------
+    swmm_out : SWMM model output file 
+    object_ids : SWMM model node/link ID (eg. ['a','b'] : list of links or nodes) 
+    attribute : python  swmm library attribute for type of data 
+        (eg. for link flow rate: output.LinkAttribute.FLOW_RATE)
+
+    Returns
+    -------
+    Pandas dataframe time series for the "object_ids"
+
+    '''
+
+    # open handle
+    handle = output.init()
+    output.open(handle, swmm_out)
+    # Get Date Time array
+    date_times, num_steps = get_date_time_array(handle)
+    
+    # Extract time series data
+    objectid_values = {}
+    for objid in object_ids:
+        start_index=0
+        if object_type == 'link':
+            link_index = find_linkid_index(handle, objid)
+            values = output.get_link_series(handle,link_index, attribute, start_index, num_steps)
+        elif object_type == 'node':
+            node_index = find_nodeid_index(handle, objid)
+            values = output.get_node_series(handle,node_index, attribute, start_index, num_steps)
+        else:
+            values = []
+        objectid_values[objid] = values
+
+    # close handle
+    output.close(handle)
+
+    # read model time series into pandas dataframe
+    df = pd.DataFrame(objectid_values, index = date_times) 
+    return df
+
+


### PR DESCRIPTION
Simplifies and reduces time series extraction (from links and nodes) to single line. Only single module (wrapper) and its tests are added into the script. Therefore, there should not be any merge conflicts.